### PR TITLE
Add Rai University domain (raiuniversity.edu)

### DIFF
--- a/lib/domains/edu/raiuniversity.txt
+++ b/lib/domains/edu/raiuniversity.txt
@@ -1,0 +1,2 @@
+Rai University
+Rai University Ahmedabad


### PR DESCRIPTION
This pull request adds the email domain `raiuniversity.edu` for Rai University, a higher education institution in Ahmedabad, India.

- Official website: https://www.raiuniversity.edu
- IT-related course: https://www.raiuniversity.edu/rai-school-of-engineering-rse/
- Proof of email domain: https://drive.google.com/drive/folders/11wHgLJQfBdiTSUBtG2vOUEiAxK-1ZSYT?usp=sharing
Note: This is a screenshot from RAI University’s ERP system showing my student profile with the email `24BTCSE025@raiuniversity.edu`. I currently don’t have access to emails sent to or from this address, but I’m working with the university’s IT department (info@raiuniversity.edu) to gain access or obtain an official document confirming the domain. I can provide additional proof if needed.